### PR TITLE
Fix home link in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -9,7 +9,7 @@
        </div>
      
        <nav class="sidebar-nav">
-        <a class="sidebar-nav-item{% if page.title == 'Home' %} active{% endif %}" href="{{ '/' | absolute_url }}"><i class="fa fa-home fa-fw"></i>Home</a>
+        <a class="sidebar-nav-item{% if page.title == 'Home' %} active{% endif %}" href="{{ site.baseurl }}/"><i class="fa fa-home fa-fw"></i>Home</a>
         <a class="sidebar-nav-item{% if page.url == '/nav/getting-started/' %} active{% endif %}" href="{{ site.baseurl }}/nav/getting-started"><i class="fa fa-play fa-fw"></i> Getting Started</a>
         <a class="sidebar-nav-item{% if page.url == '/nav/course-materials/' %} active{% endif %}" href="{{ site.baseurl }}/nav/course-materials"><i class="fa fa-briefcase fa-fw"></i> Course Materials</a>
         <a class="sidebar-nav-item{% if page.url == '/schedule/' %} active{% endif %}" href="{{ site.baseurl }}/schedule"><i class="fa fa-calendar fa-fw"></i> Schedule</a>


### PR DESCRIPTION
The home link included an extra use of the `base_url` that was causing a 404. 